### PR TITLE
Convert posts to Markdown with dark mode and likes

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,16 +1,30 @@
 import Head from 'next/head';
-import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import Nav from './Nav';
 
 export default function Layout({ children }) {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('dark');
+    if (stored === 'true') setDark(true);
+  }, []);
+
+  useEffect(() => {
+    document.body.className = dark ? 'dark' : '';
+    localStorage.setItem('dark', dark);
+  }, [dark]);
+
   return (
     <div className="container">
       <Head>
         <title>Modern Blog</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <nav>
-        <Link href="/">Home</Link>
-      </nav>
+      <Nav />
+      <button onClick={() => setDark(!dark)} aria-label="toggle-dark">
+        {dark ? 'Light' : 'Dark'} Mode
+      </button>
       {children}
     </div>
   );

--- a/components/LikeButton.js
+++ b/components/LikeButton.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export default function LikeButton({ postId }) {
+  const [likes, setLikes] = useState(0);
+  const storageKey = `likes_${postId}`;
+
+  useEffect(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) setLikes(parseInt(stored, 10));
+  }, [storageKey]);
+
+  const handleLike = () => {
+    const newLikes = likes + 1;
+    setLikes(newLikes);
+    localStorage.setItem(storageKey, newLikes);
+  };
+
+  return (
+    <button onClick={handleLike} aria-label="like">
+      ❤️ {likes}
+    </button>
+  );
+}

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -1,0 +1,9 @@
+import Link from 'next/link';
+
+export default function Nav() {
+  return (
+    <nav>
+      <Link href="/">Home</Link>
+    </nav>
+  );
+}

--- a/components/PostCard.js
+++ b/components/PostCard.js
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function PostCard({ post }) {
+  return (
+    <div className="post-card">
+      <h2>
+        <Link href={`/posts/${post.id}`}>{post.title}</Link>
+      </h2>
+      <p>{post.excerpt}</p>
+      {post.tags && (
+        <p className="tags">{post.tags.join(', ')}</p>
+      )}
+    </div>
+  );
+}

--- a/data/posts.js
+++ b/data/posts.js
@@ -1,18 +1,36 @@
-module.exports = [
-  {
-    id: 'welcome',
-    title: 'Welcome to the Blog',
-    excerpt: 'Introducing our new modern blog built with Next.js.',
-    content: `# Welcome
+const fs = require('fs');
+const path = require('path');
 
-This is the first post on our modern blog. Stay tuned for more content!`
-  },
-  {
-    id: 'second-post',
-    title: 'Another Post',
-    excerpt: 'Here\'s another example post.',
-    content: `# Second Post
+const postsDir = path.join(__dirname, '..', 'posts');
 
-More content goes here. We hope you enjoy reading.`
+function parsePost(content) {
+  const match = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/m.exec(content);
+  let meta = {};
+  if (match) {
+    const lines = match[1].split(/\n/);
+    for (const line of lines) {
+      const [key, ...rest] = line.split(':');
+      meta[key.trim()] = rest.join(':').trim();
+    }
+    content = match[2].trim();
   }
-];
+  return { ...meta, content };
+}
+
+const posts = fs.readdirSync(postsDir)
+  .filter(f => f.endsWith('.md'))
+  .map(filename => {
+    const file = fs.readFileSync(path.join(postsDir, filename), 'utf8');
+    const data = parsePost(file);
+    const id = data.id || filename.replace(/\.md$/, '');
+    const tags = data.tags ? data.tags.split(',').map(t => t.trim()) : [];
+    return {
+      id,
+      title: data.title || id,
+      excerpt: data.excerpt || '',
+      content: data.content || '',
+      tags,
+    };
+  });
+
+module.exports = posts;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,22 +1,43 @@
-import Link from 'next/link';
-import posts from '../data/posts';
+import { useState } from 'react';
+import postsData from '../data/posts';
 import Layout from '../components/Layout';
+import PostCard from '../components/PostCard';
 
 export async function getStaticProps() {
-  return { props: { posts } };
+  return { props: { posts: postsData } };
 }
 
 export default function Home({ posts }) {
+  const [query, setQuery] = useState('');
+  const [tag, setTag] = useState('');
+
+  const allTags = Array.from(new Set(posts.flatMap(p => p.tags)));
+
+  const filtered = posts.filter(p => {
+    const matchesTag = tag ? p.tags.includes(tag) : true;
+    const q = query.toLowerCase();
+    const matchesQuery = p.title.toLowerCase().includes(q) ||
+      p.content.toLowerCase().includes(q);
+    return matchesTag && matchesQuery;
+  });
+
   return (
     <Layout>
       <h1>Modern Blog</h1>
-      {posts.map(post => (
-        <div key={post.id}>
-          <h2>
-            <Link href={`/posts/${post.id}`}>{post.title}</Link>
-          </h2>
-          <p>{post.excerpt}</p>
-        </div>
+      <input
+        type="text"
+        placeholder="Search"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
+      <select value={tag} onChange={e => setTag(e.target.value)}>
+        <option value="">All</option>
+        {allTags.map(t => (
+          <option key={t} value={t}>{t}</option>
+        ))}
+      </select>
+      {filtered.map(post => (
+        <PostCard key={post.id} post={post} />
       ))}
     </Layout>
   );

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,6 +1,8 @@
 import ReactMarkdown from 'react-markdown';
 import posts from '../../data/posts';
 import Layout from '../../components/Layout';
+import LikeButton from '../../components/LikeButton';
+import { useEffect } from 'react';
 
 export async function getStaticPaths() {
   const paths = posts.map(post => ({ params: { id: post.id } }));
@@ -13,10 +15,23 @@ export async function getStaticProps({ params }) {
 }
 
 export default function Post({ post }) {
+  useEffect(() => {
+    if (window.DISQUS === undefined) {
+      const d = document, s = d.createElement('script');
+      s.src = 'https://example.disqus.com/embed.js';
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    } else {
+      window.DISQUS.reset({ reload: true });
+    }
+  }, [post.id]);
+
   return (
     <Layout>
       <h1>{post.title}</h1>
+      <LikeButton postId={post.id} />
       <ReactMarkdown>{post.content}</ReactMarkdown>
+      <div id="disqus_thread" />
     </Layout>
   );
 }

--- a/posts/second-post.md
+++ b/posts/second-post.md
@@ -1,0 +1,10 @@
+---
+id: second-post
+title: Another Post
+excerpt: Here's another example post.
+tags: example
+---
+
+# Second Post
+
+More content goes here. We hope you enjoy reading.

--- a/posts/welcome.md
+++ b/posts/welcome.md
@@ -1,0 +1,10 @@
+---
+id: welcome
+title: Welcome to the Blog
+excerpt: Introducing our new modern blog built with Next.js.
+tags: intro, nextjs
+---
+
+# Welcome
+
+This is the first post on our modern blog. Stay tuned for more content!

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,6 +7,11 @@ body {
   color: #333;
 }
 
+body.dark {
+  background: #222;
+  color: #eee;
+}
+
 .container {
   max-width: 800px;
   margin: 0 auto;
@@ -14,10 +19,24 @@ body {
   background: #fff;
 }
 
+body.dark .container {
+  background: #333;
+}
+
 nav a {
   margin-right: 1rem;
   color: #0070f3;
   text-decoration: none;
+}
+
+.post-card {
+  border-bottom: 1px solid #ccc;
+  padding: 1rem 0;
+}
+
+.tags {
+  font-size: 0.8rem;
+  color: #666;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- convert posts data to Markdown files
- parse Markdown front matter at build time
- add like button and Disqus comments
- implement simple search and tag filter
- add dark mode toggle
- style updates for post cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589a4b4c1c8333b7e3ffb9b05609b2