### PR TITLE
Support auto-loading posts

### DIFF
--- a/data/posts.js
+++ b/data/posts.js
@@ -18,20 +18,24 @@ function parsePost(content) {
   return { ...meta, content };
 }
 
-const posts = fs.readdirSync(postsDir)
-  .filter(f => f.endsWith('.md'))
-  .map(filename => {
-    const file = fs.readFileSync(path.join(postsDir, filename), 'utf8');
-    const data = parsePost(file);
-    const id = data.id || filename.replace(/\.md$/, '');
-    const tags = data.tags ? data.tags.split(',').map(t => t.trim()) : [];
-    return {
-      id,
-      title: data.title || id,
-      excerpt: data.excerpt || '',
-      content: data.content || '',
-      tags,
-    };
-  });
+function getPosts() {
+  return fs.readdirSync(postsDir)
+    .filter(f => f.endsWith('.md'))
+    .map(filename => {
+      const file = fs.readFileSync(path.join(postsDir, filename), 'utf8');
+      const data = parsePost(file);
+      const id = data.id || filename.replace(/\.md$/, '');
+      const tags = data.tags ? data.tags.split(',').map(t => t.trim()) : [];
+      return {
+        id,
+        title: data.title || id,
+        excerpt: data.excerpt || '',
+        content: data.content || '',
+        tags,
+      };
+    });
+}
 
-module.exports = posts;
+module.exports = {
+  getPosts,
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import postsData from '../data/posts';
+import { getPosts } from '../data/posts';
 import Layout from '../components/Layout';
 import PostCard from '../components/PostCard';
 
-export async function getStaticProps() {
-  return { props: { posts: postsData } };
+export async function getServerSideProps() {
+  const posts = getPosts();
+  return { props: { posts } };
 }
 
 export default function Home({ posts }) {

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,16 +1,15 @@
 import ReactMarkdown from 'react-markdown';
-import posts from '../../data/posts';
+import { getPosts } from '../../data/posts';
 import Layout from '../../components/Layout';
 import LikeButton from '../../components/LikeButton';
 import { useEffect } from 'react';
 
-export async function getStaticPaths() {
-  const paths = posts.map(post => ({ params: { id: post.id } }));
-  return { paths, fallback: false };
-}
-
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+  const posts = getPosts();
   const post = posts.find(p => p.id === params.id);
+  if (!post) {
+    return { notFound: true };
+  }
   return { props: { post } };
 }
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
-const posts = require('./data/posts');
+const { getPosts } = require('./data/posts');
+const posts = getPosts();
 
 assert(Array.isArray(posts), 'posts should be an array');
 assert(posts.length > 0, 'posts should not be empty');


### PR DESCRIPTION
## Summary
- load posts dynamically when requested
- fetch posts on every request for the index page
- fetch individual posts on every request
- update tests to use the new function

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624349c7e483338eb15b34b4027e7a